### PR TITLE
Amend link target for 'Contact the creators'

### DIFF
--- a/wagtailio/core/templates/core/includes/contact_torchbox.html
+++ b/wagtailio/core/templates/core/includes/contact_torchbox.html
@@ -3,7 +3,7 @@
     <div class="pane__hire__container">
         <h2 class="heading--light">Need an Agency?</h2>
         <p>We've got you covered. <a href="https://torchbox.com">Torchbox</a> created Wagtail to help awesome people make great websites. There is also a <a href="https://madewithwagtail.org/">global network of partners</a> to support you. We’d love to hear from you if you’d like to work together.</p>
-        <a href="https://torchbox.com/contact" class="view-all btn btn--outline btn--outline--light">Contact Torchbox, the creators of Wagtail <svg height="30px" width="30px"><use xlink:href="#arrow"></use></svg></a>
+        <a href="https://torchbox.com/wagtail-cms" class="view-all btn btn--outline btn--outline--light">Contact Torchbox, the creators of Wagtail <svg height="30px" width="30px"><use xlink:href="#arrow"></use></svg></a>
     </div> <!-- /pane__hire__container -->
 
 </section> <!-- /hire -->


### PR DESCRIPTION
Changes the link to 'Contact Torchbox' to the wagtail cms page (which has an enquiries link), rather than to the general torchbox contact form.