### PR TITLE
Restrict page hierarchy

### DIFF
--- a/wagtailio/blog/models.py
+++ b/wagtailio/blog/models.py
@@ -16,6 +16,8 @@ from wagtailio.utils.models import (
 
 
 class BlogIndexPage(Page, SocialMediaMixin, CrossPageMixin):
+    subpage_types = ['blog.BlogPage']
+
     def serve(self, request):
         latest_blog = BlogPage.objects.live().order_by('-date').first()
         return redirect(latest_blog.url)
@@ -48,6 +50,7 @@ class Author(models.Model):
 
 
 class BlogPage(Page, SocialMediaMixin, CrossPageMixin):
+    subpage_types = []
     canonical_url = models.URLField(blank=True)
     author = models.ForeignKey(
         'blog.Author',

--- a/wagtailio/core/models.py
+++ b/wagtailio/core/models.py
@@ -13,7 +13,14 @@ from wagtailio.utils.models import SocialMediaMixin, CrossPageMixin
 
 class HomePage(Page, SocialMediaMixin, CrossPageMixin):
     body = StreamField(HomePageBlock())
-
+    parent_page_types = ['wagtailcore.Page']
+    subpage_types = [
+        'blog.BlogIndexPage',
+        'developers.DevelopersPage',
+        'features.FeatureIndexPage',
+        'newsletter.NewsletterIndexPage',
+        'standardpage.StandardPage',
+    ]
     content_panels = Page.content_panels + [
         StreamFieldPanel('body'),
     ]

--- a/wagtailio/utils/models.py
+++ b/wagtailio/utils/models.py
@@ -77,7 +77,7 @@ register_snippet(MenuSnippet)
 
 class SocialMediaMixin(models.Model):
     social_text = models.CharField("Meta description", max_length=255, blank=True, help_text="Description of this page as it should appear when shared on social networks, or in Google results")
-    social_image = models.ForeignKey('images.WagtailIOImage', models.SET_NULL, verbose_name="Meta image", null=True, blank=True, related_name='+', help_text="Image to appear alongside 'Meta descro[topm', particularly for sharing on social networks",)
+    social_image = models.ForeignKey('images.WagtailIOImage', models.SET_NULL, verbose_name="Meta image", null=True, blank=True, related_name='+', help_text="Image to appear alongside 'Meta description', particularly for sharing on social networks",)
 
     panels = [
         MultiFieldPanel([


### PR DESCRIPTION
Restricted a few child page types. Threw in a quick help_text typo fix. 