### PR TITLE
Primary MenuSnippet Exception

### DIFF
--- a/wagtailio/utils/templatetags/wagtailio_utils.py
+++ b/wagtailio/utils/templatetags/wagtailio_utils.py
@@ -10,7 +10,10 @@ register = template.Library()
 
 @register.inclusion_tag('includes/menu_primary.html', takes_context=True)
 def menu_primary(context):
-    menu = MenuSnippet.objects.get(menu_name__iexact='primary')
+    try:
+        menu = MenuSnippet.objects.get(menu_name__iexact='primary')
+    except MenuSnippet.DoesNotExist:
+        return {}
 
     return {
         'links': menu.links.all(),


### PR DESCRIPTION
I was spinning up the Vagrant box and ran into this, thought I'd catch the `DoesNotExist` exception so the base.html template will render even without a menu. 