### PR TITLE
Version bumps: Django 2.1.13, Wagtail 2.3, Pillow 5.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-Django==2.0.13
+Django==2.1.13
 dj-database-url==0.5.0
-wagtail==2.2
+wagtail==2.3
 psycopg2==2.7.4
 libsass==0.8.3
-Pillow>=2.6.1
+Pillow==5.4.1
 embedly==0.5.0
 Markdown==2.6.11
 Pygments==2.2.0


### PR DESCRIPTION
Upgrading Wagtail to v2.3. I recall some Django version issues around this time, so I pinned Django to 2.1.13 and will update Django as Wagtail gets updated. 

There was a Pillow warning. Pillow 6.2.0 was being installed but `<6.0` was required for Wagtail 2.3, so I pinned the latest accepted version of Pillow which was `5.4.1`.

Running the site locally seemed to work fine for me, but I'm not sure if there's a preferred way to test a production-like site just to check. It'd be great if someone else could also make sure the requirements don't break wagtail.io before deploying. 