### PR TITLE
update blog.scss - ensure menu hides on sm devices

### DIFF
--- a/wagtailio/static/css/core/blog.scss
+++ b/wagtailio/static/css/core/blog.scss
@@ -141,7 +141,7 @@
         position: absolute;
         width: 100%;
         height: 100%;
-        transform: translate3d(0, -200%, 0);
+        transform: translate3d(0, -300%, 0);
         background-color: $headingColor;
         z-index: 4;
         opacity: 0;


### PR DESCRIPTION
* Note: quick fix
* due to the long list of blog posts, -200% is not enough to 'hide' all the blog listing
* ideally the blog listing should be completely hidden on mobile, however, display: none causes some flickering of the menu on scrolling