### PR TITLE
Upgrade Wagtail to 2.8 and Django to 2.2.10 LTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django==2.2.9
+Django==2.2.10
 dj-database-url==0.5.0
-wagtail==2.5.2
+wagtail==2.8
 psycopg2==2.7.4
 libsass==0.8.3
 Pillow==5.4.1
@@ -15,7 +15,7 @@ brotlipy==0.7.0
 django-storages==1.6.6
 boto3==1.7.82
 django-redis==4.9.0
-django-basic-auth-ip-whitelist==0.2
+django-basic-auth-ip-whitelist==0.2.1
 scout-apm==1.1.7
 django-referrer-policy==1.0
 

--- a/wagtailio/core/wagtail_hooks.py
+++ b/wagtailio/core/wagtail_hooks.py
@@ -5,7 +5,8 @@ from django.utils.cache import add_never_cache_headers
 from django.utils.html import format_html, format_html_join
 from wagtail.core import hooks
 from wagtail.core.whitelist import allow_without_attributes
-from wagtail.documents.models import document_served, get_document_model
+from wagtail.documents import get_document_model
+from wagtail.documents.models import document_served
 
 from storages.backends.s3boto3 import S3Boto3Storage
 


### PR DESCRIPTION
This pull request will upgrade Wagtail to the latest 2.8 release.

- Django was upgraded to 2.2.10 to fix a recent security vulnerability.
- django-basic-auth-ip-whitelist was also upgraded to fix a compatibility warning with Django.
- In Wagtail 2.8 `get_document_model()` was moved. https://docs.wagtail.io/en/v2.8/releases/2.8.html#wagtail-documents-models-get-document-model-has-moved.

The upgrade process was very smooth. Kudos Wagtail developers 👌 