### PR TITLE
Add styling for inline code blocks

### DIFF
--- a/wagtailio/static/css/core/base.scss
+++ b/wagtailio/static/css/core/base.scss
@@ -30,6 +30,14 @@ a {
     }
 }
 
+code {
+    background-color: #eee;
+    border-radius: 3px;
+    font-family: courier, monospace;
+    font-size: .85em;
+    padding: 0 3px;
+}
+
 img {
     height: auto; // overwrite inline height added via django templating (possibly a bad assumption to make!)
     vertical-align: top; // render images as we would just expect them to render (without mystical padding bottom)


### PR DESCRIPTION
This fixes #26.

With this PR inline code blocks now look like this: 
![image](https://user-images.githubusercontent.com/13856515/74140630-585c5580-4bed-11ea-9ee8-8ad36087b864.png)
