### PR TITLE
Fix migrate command on release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .DS_Store
 *.swp
+.vscode/
 /venv/
 /static/
 /media/

--- a/heroku.yml
+++ b/heroku.yml
@@ -4,6 +4,4 @@ build:
 release:
   image: web
   command:
-    - django-admin createcachetable
-    - django-admin migrate --noinput
-
+    - django-admin createcachetable && django-admin migrate --noinput


### PR DESCRIPTION
This fixes #28 

Migrations were not being run because Heroku apparently only accepts a single release command entry anymore. Not sure why but with this fix it should be working again!