### PR TITLE
Blog listing thumbnail center around focal point

### DIFF
--- a/wagtailio/core/templates/core/home_page.html
+++ b/wagtailio/core/templates/core/home_page.html
@@ -24,7 +24,7 @@
                         <a class="latest-item__link" href="{% pageurl blog_post %}">
                             <div class="latest-item__image-container"
                                 {% if blog_post.listing_image or blog_post.main_image %}
-                                    {% image blog_post.listing_image|default:blog_post.main_image fill-360x400 as bg_image %}
+                                    {% image blog_post.listing_image|default:blog_post.main_image fill-360x400-c85 as bg_image %}
                                     style="background-image: url({{ bg_image.url }});"
                                 {% else %}
                                     style="background-image: url({% static 'img/hero_bg_3.jpg' %});"


### PR DESCRIPTION
Currently, the thumbnails of the blog listing on the homepage (all the way at the bottom) don't center around the focal area. This can look kind of akward:
![Screenshot 2020-02-10 at 16 49 49](https://user-images.githubusercontent.com/13856515/74170820-67f79080-4c25-11ea-8112-2ca75b2b0213.png)

This PR centers the cropping of the thumbnail around the focal area. This results in much better results:
![Screenshot 2020-02-10 at 16 51 39](https://user-images.githubusercontent.com/13856515/74170961-a42af100-4c25-11ea-945d-9ce1e3ed8f0a.png)

