### PR TITLE
A11Y improvements on newsletter page

### DIFF
--- a/wagtailio/newsletter/templates/newsletter/newsletter_page.html
+++ b/wagtailio/newsletter/templates/newsletter/newsletter_page.html
@@ -715,20 +715,20 @@
         }
     </style>
     <style>
-        a{
-          color: #43b1b0;
+        a {
+          color: #1b7894;
           text-decoration: underline;
         }
         a:hover {
-          color: #ff574a !important;
+          color: #cc362a !important;
         }
 
         a:active {
-          color: #ff574a !important;
+          color: #cc362a !important;
         }
 
         a:visited {
-          color: #ff574a !important;
+          color: #cc362a !important;
         }
 
         a.view-online {
@@ -736,7 +736,7 @@
         }
 
         h1 {
-          color: #ff574a;
+          color: #e55043;
           margin-bottom: 20px;
           font-size: 30px;
         }
@@ -745,9 +745,9 @@
           margin-bottom: 10px;
         }
 
-        h2{
+        h2 {
           margin-top: 30px;
-          color: #ff574a;
+          color: #e55043;
           font-size:25px;
         }
         p.date {


### PR DESCRIPTION
This fixes #2

I have made the headings and links slightly darker to provide enough contrast on the white background.

![Screenshot 2020-02-11 at 14 48 29](https://user-images.githubusercontent.com/13856515/74247766-7fdf1b00-4cde-11ea-959a-62999f235e27.png)

Link colors now pass WCAG AA where they previously did not.
