### PR TITLE
Fixes for mobile responsiveness

### DIFF
--- a/wagtailio/core/templates/core/includes/contact_torchbox.html
+++ b/wagtailio/core/templates/core/includes/contact_torchbox.html
@@ -2,6 +2,6 @@
     <div class="hire__container">
         <h2 class="hire__heading">Need an Agency?</h2>
         <p class="hire__description">We've got you covered. <a href="https://torchbox.com">Torchbox</a> created Wagtail to help awesome people make great websites. There is also a <a href="https://madewithwagtail.org/">global network of partners</a> to support you. We’d love to hear from you if you’d like to work together.</p>
-        <a href="https://torchbox.com/wagtail-cms" class="hire__cta button">Contact Torchbox, the creators of Wagtail</a>
+        <a href="https://torchbox.com/wagtail-cms/" class="hire__cta button">Contact Torchbox, the creators of Wagtail</a>
     </div> 
 </section> 

--- a/wagtailio/static/css/components/actions.scss
+++ b/wagtailio/static/css/components/actions.scss
@@ -7,7 +7,7 @@
   margin-bottom: ($gutter * 2);
   overflow: hidden;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding-left: 0;
     margin-bottom: 0;
   }
@@ -79,7 +79,7 @@
     right: 0;
     margin: 0;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       right: $gutter;
     }
 

--- a/wagtailio/static/css/components/base.scss
+++ b/wagtailio/static/css/components/base.scss
@@ -112,7 +112,7 @@ Other global items
 .mobile-only {
   display: block;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     display: none;
   }
 }

--- a/wagtailio/static/css/components/blog.scss
+++ b/wagtailio/static/css/components/blog.scss
@@ -15,7 +15,7 @@
   padding: $headerHeight $gutter;
   background-color: $color--white;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     margin-left: $sidebarWidth;
     padding: $headerHeight ($gutter * 2);
   }
@@ -86,7 +86,7 @@
   margin: 0;
   padding: 0;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     position: absolute;
     top: 0;
     left: 0;
@@ -151,7 +151,7 @@
     opacity: 0;
     transition: transform 0.2s ease 0s, opacity 0.2s ease 0s;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       transform: translate3d(0, 0%, 0);
       position: relative;
       background-color: transparent;
@@ -174,7 +174,7 @@
     position: relative;
     transition: padding 0.2s ease 0s;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: ($gutter * 5) 40px ($gutter);
       text-align: left;
     }
@@ -182,7 +182,7 @@
     h2 {
       display: none;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         display: block;
       }
     }
@@ -192,7 +192,7 @@
       font-weight: bold;
       text-transform: uppercase;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         visibility: hidden;
       }
 
@@ -219,7 +219,7 @@
 .template-blog-page .body {
   padding-top: 0;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding-top: $headerHeight;
   }
 }
@@ -228,7 +228,7 @@
   .blog-nav__header {
     padding: 26px 40px ($gutter);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: 26px 40px ($gutter);
       text-align: left;
     }

--- a/wagtailio/static/css/components/blog.scss
+++ b/wagtailio/static/css/components/blog.scss
@@ -200,10 +200,6 @@
         fill: $color--white;
         transition: transform 0.2s ease 0s;
       }
-
-      &:hover {
-        color: $color--black;
-      }
     }
 
     .sidebar-open & {

--- a/wagtailio/static/css/components/example-item.scss
+++ b/wagtailio/static/css/components/example-item.scss
@@ -12,7 +12,7 @@
     display: none;
   }
 
-  @include media-query(medium) {
+  @include media-query(small) {
     flex-basis: 50%;
     max-width: 50%;
 

--- a/wagtailio/static/css/components/examples.scss
+++ b/wagtailio/static/css/components/examples.scss
@@ -32,7 +32,7 @@
     padding: 0;
     margin: 0 0 ($gutter * 2);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: 0 $gutter * 3;
     }
   }

--- a/wagtailio/static/css/components/feature-item.scss
+++ b/wagtailio/static/css/components/feature-item.scss
@@ -1,15 +1,5 @@
 .feature-item {
-  flex-basis: 100%;
-  max-width: 100%;
-  min-width: 100%;
   margin-bottom: ($gutter * 2);
-
-  @include media-query(medium) {
-    flex-basis: 25%;
-    max-width: 25%;
-    min-width: 25%;
-    padding: 0 ($gutter);
-  }
 
   &__heading {
     font-size: 16px;

--- a/wagtailio/static/css/components/feature-item.scss
+++ b/wagtailio/static/css/components/feature-item.scss
@@ -4,7 +4,7 @@
   &__heading {
     font-size: 16px;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       font-size: 18px;
     }
   }
@@ -12,7 +12,7 @@
   &__description {
     font-size: 13px;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       font-size: 14px;
     }
   }

--- a/wagtailio/static/css/components/features.scss
+++ b/wagtailio/static/css/components/features.scss
@@ -1,6 +1,6 @@
 .features {
   &__container {
-    margin: 0 auto;
+    margin: 0 $gutter;
     max-width: $max-width;
   }
 

--- a/wagtailio/static/css/components/features.scss
+++ b/wagtailio/static/css/components/features.scss
@@ -13,7 +13,7 @@
     grid-template-columns: 1fr;
     margin-bottom: ($gutter * 2);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       grid-template-columns: 1fr 3fr;
     }
   }
@@ -34,7 +34,7 @@
     grid-template-columns: 1fr;
     column-gap: $gutter;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       grid-template-columns: 1fr 1fr;
     }
 
@@ -63,7 +63,7 @@
     .tab-content {
       width: 100%;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         width: 70%;
       }
 
@@ -77,7 +77,7 @@
         margin-bottom: 0;
         border: $gutter solid $color--primary;
 
-        @include media-query(medium) {
+        @include media-query(small) {
           border: ($gutter * 2) solid $color--primary;
         }
 
@@ -87,7 +87,7 @@
           .button {
             margin-bottom: ($gutter * 2);
 
-            @include media-query(medium) {
+            @include media-query(small) {
               float: right;
               margin-bottom: 0;
             }
@@ -141,7 +141,7 @@
   overflow: hidden;
   display: none;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     display: flex;
     justify-content: space-between;
   }
@@ -200,7 +200,7 @@
     font-size: 15px;
     font-weight: bold;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       font-size: 18px;
       top: -61px;
       padding: $gutter $gutter * 3;
@@ -214,7 +214,7 @@
   header {
     padding: $gutter 0;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: ($gutter * 2) 0;
       float: left;
       width: 20%;
@@ -228,7 +228,7 @@
   .row {
     padding: $gutter * 2 0 $gutter;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       float: left;
       width: 80%;
       margin-left: -$gutter;
@@ -242,7 +242,7 @@
     text-align: left;
     padding: 0 $gutter * 0.75 $gutter;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       flex-basis: 25%;
     }
 
@@ -256,7 +256,7 @@
   overflow: hidden;
   padding: 0 $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding: 0 $gutter * 3;
   }
 

--- a/wagtailio/static/css/components/features.scss
+++ b/wagtailio/static/css/components/features.scss
@@ -2,6 +2,10 @@
   &__container {
     margin: 0 $gutter;
     max-width: $max-width;
+
+    @include media-query(large) {
+      margin: 0 ($gutter * 4);
+    }
   }
 
   &__section {

--- a/wagtailio/static/css/components/features.scss
+++ b/wagtailio/static/css/components/features.scss
@@ -5,43 +5,39 @@
   }
 
   &__section {
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: 1fr;
     margin-bottom: ($gutter * 2);
+
+    @include media-query(medium) {
+      grid-template-columns: 1fr 3fr;
+    }
   }
 
   &__heading {
-    margin-bottom: ($gutter * 4);
+    margin-bottom: ($gutter * 3);
   }
 
   &__sub-heading {
-    flex-basis: 100%;
-    max-width: 100%;
-    min-width: 100%;
+    min-width: 20%;
     font-size: 18px;
     text-transform: uppercase;
     margin-bottom: ($gutter);
-
-    @include media-query(medium) {
-      flex-basis: 20%;
-      max-width: 20%;
-      min-width: 20%;
-    }
   }
 
   &__content {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    flex-basis: 100%;
-    max-width: 100%;
-    min-width: 100%;
+    display: grid;
+    grid-template-columns: 1fr;
+    column-gap: $gutter;
 
     @include media-query(medium) {
-      flex-basis: 80%;
-      max-width: 80%;
-      min-width: 80%;
+      grid-template-columns: 1fr 1fr;
     }
+
+    @include media-query(large) {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+    
   }
 }
 

--- a/wagtailio/static/css/components/follow-links.scss
+++ b/wagtailio/static/css/components/follow-links.scss
@@ -16,7 +16,7 @@
   }
 
   .footer & {
-    @include media-query(medium) {
+    @include media-query(small) {
       flex-basis: 33.33%;
       max-width: 33.33%;
       min-width: 33.33%;

--- a/wagtailio/static/css/components/footer.scss
+++ b/wagtailio/static/css/components/footer.scss
@@ -7,7 +7,7 @@
   text-align: left;
   background-color: $color--background-light;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding: ($gutter * 3);
   }
 
@@ -17,7 +17,7 @@
   }
 
   &__row {
-    @include media-query(medium) {
+    @include media-query(small) {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
@@ -30,7 +30,7 @@
     border-bottom: 1px solid rgba($color--border, 0.2);
     padding-bottom: ($gutter / 2);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       font-size: 24px;
     }
   }
@@ -71,7 +71,7 @@
   padding-bottom: 10px;
   margin-bottom: $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     margin-bottom: 0;
   }
 
@@ -86,7 +86,7 @@
 .network_links {
   margin-bottom: $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     margin-bottom: 0;
   }
 
@@ -105,7 +105,7 @@
     padding: ($gutter / 2) 0;
     margin: 0;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: $gutter 0;
     }
 
@@ -133,7 +133,7 @@
 .latest_blog {
   margin-bottom: $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     margin-bottom: 0;
   }
 
@@ -164,7 +164,7 @@
 .newsletter_signup {
   margin-bottom: $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     margin-bottom: 0;
   }
 

--- a/wagtailio/static/css/components/get-started.scss
+++ b/wagtailio/static/css/components/get-started.scss
@@ -6,7 +6,7 @@
   }
 
   .footer & {
-    @include media-query(medium) {
+    @include media-query(small) {
       flex-basis: 100%;
       max-width: 100%;
       min-width: 100%;

--- a/wagtailio/static/css/components/headings.scss
+++ b/wagtailio/static/css/components/headings.scss
@@ -3,7 +3,7 @@
     font-size: 15px;
     font-weight: 700;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       font-size: 18px;
     }
   }
@@ -13,7 +13,7 @@
     padding-top: ($gutter * 0.75);
     border-top: 2px solid $color--primary;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       display: inline-block;
     }
   }
@@ -37,7 +37,7 @@ h1 {
   margin: 0 0 ($gutter / 2);
   line-height: 1.2;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     font-size: 56px;
   }
 }
@@ -46,7 +46,7 @@ h2 {
   font-size: 28px;
   margin: 0 0 $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     font-size: 42px;
   }
 }
@@ -56,7 +56,7 @@ h3 {
   margin: 0 0 5px;
   font-weight: 800;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     font-size: 21px;
   }
 }
@@ -65,7 +65,7 @@ h4 {
   font-size: 16px;
   margin: 0 0 5px;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     font-size: 18px;
   }
 }

--- a/wagtailio/static/css/components/hero.scss
+++ b/wagtailio/static/css/components/hero.scss
@@ -8,7 +8,7 @@
   height: auto;
   max-height: 800px;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     height: 700px;
     padding-top: $headerHeight;
   }
@@ -32,7 +32,7 @@
     z-index: 0;
     display: none;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       display: block;
     }
   }
@@ -48,7 +48,7 @@
     width: 100%;
     padding: ($gutter * 2);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       width: 50%;
       padding: ($gutter * 5) 0 0 ($gutter * 3);
     }
@@ -63,7 +63,7 @@
       font-weight: 700;
       color: $color--quaternary;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         font-size: 18px;
       }
     }
@@ -90,7 +90,7 @@
     width: 50%;
     height: auto;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       display: block;
       width: 40%;
     }

--- a/wagtailio/static/css/components/hero.scss
+++ b/wagtailio/static/css/components/hero.scss
@@ -41,6 +41,7 @@
     position: relative;
     max-width: $max-width;
     margin: 0 auto;
+    z-index: 1;
   }
 
   .text-container {

--- a/wagtailio/static/css/components/horizontal-tabs.scss
+++ b/wagtailio/static/css/components/horizontal-tabs.scss
@@ -39,7 +39,7 @@
     text-align: center;
     display: none;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       margin-bottom: 0;
       display: block;
     }
@@ -47,7 +47,7 @@
     li {
       display: block;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         display: inline-block;
       }
 
@@ -64,7 +64,7 @@
         color: $color--interaction;
         transition: color 0.2s ease 0s, border 0.2s ease 0s;
 
-        @include media-query(medium) {
+        @include media-query(small) {
           margin: 0 $gutter 40px;
         }
 
@@ -97,7 +97,7 @@
       display: block;
       margin: ($gutter * 2) auto;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         display: none;
       }
     }
@@ -110,7 +110,7 @@
 
       text-shadow: 1px 1px 1px rgba($color--white, 0.2);
 
-      @include media-query(medium) {
+      @include media-query(small) {
         font-size: 21px;
       }
 

--- a/wagtailio/static/css/components/latest-blog.scss
+++ b/wagtailio/static/css/components/latest-blog.scss
@@ -23,7 +23,7 @@
   }
 
   .footer & {
-    @include media-query(medium) {
+    @include media-query(small) {
       flex-basis: 50%;
       max-width: 50%;
       min-width: 50%;

--- a/wagtailio/static/css/components/latest-item.scss
+++ b/wagtailio/static/css/components/latest-item.scss
@@ -1,12 +1,8 @@
 .latest-item {
   $root: &;
-  flex-basis: 100%;
-  max-width: 100%;
   padding: 0 0 $gutter;
 
   @include media-query(medium) {
-    flex-basis: 33.333%;
-    max-width: 33.333%;
     padding: 0 ($gutter * 2) ($gutter * 2) 0;
   }
 

--- a/wagtailio/static/css/components/latest-item.scss
+++ b/wagtailio/static/css/components/latest-item.scss
@@ -2,7 +2,7 @@
   $root: &;
   padding: 0 0 $gutter;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding: 0 ($gutter * 2) ($gutter * 2) 0;
   }
 

--- a/wagtailio/static/css/components/latest.scss
+++ b/wagtailio/static/css/components/latest.scss
@@ -17,11 +17,11 @@
   }
 
   &__content {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
 
-    @include media-query(medium) {
-      flex-direction: row;
+    @include media-query(large) {
+      grid-template-columns: 1fr 1fr 1fr;
     }
   }
 

--- a/wagtailio/static/css/components/latest.scss
+++ b/wagtailio/static/css/components/latest.scss
@@ -2,7 +2,7 @@
   padding: ($section-space / 2) ($gutter * 2);
   background: $color--background-light;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding: ($section-space / 2) ($gutter * 4);
   }
 

--- a/wagtailio/static/css/components/logo-list.scss
+++ b/wagtailio/static/css/components/logo-list.scss
@@ -18,7 +18,7 @@
     margin-right: $gutter;
     margin-bottom: 0;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       text-align: left;
       font-size: 18px;
       margin-left: ($gutter * 2);
@@ -30,7 +30,7 @@
     display: none;
     padding: $gutter $gutter ($gutter * 2);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: $gutter ($gutter * 2) ($gutter * 3);
     }
 
@@ -57,7 +57,7 @@
       right: 0;
       text-align: center;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         bottom: $gutter;
       }
 

--- a/wagtailio/static/css/components/logo.scss
+++ b/wagtailio/static/css/components/logo.scss
@@ -5,7 +5,7 @@
   &__logo {
     width: 70px;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       width: 90px;
     }
   }

--- a/wagtailio/static/css/components/nav-item.scss
+++ b/wagtailio/static/css/components/nav-item.scss
@@ -3,7 +3,6 @@
   display: flex;
   align-items: center;
   margin: 0;
-  white-space: nowrap;
 
   .primary-nav & {
     @include font-smoothing();

--- a/wagtailio/static/css/components/nav-item.scss
+++ b/wagtailio/static/css/components/nav-item.scss
@@ -3,6 +3,7 @@
   display: flex;
   align-items: center;
   margin: 0;
+  white-space: nowrap;
 
   .primary-nav & {
     @include font-smoothing();

--- a/wagtailio/static/css/components/network-links.scss
+++ b/wagtailio/static/css/components/network-links.scss
@@ -13,7 +13,7 @@
     font-size: 13px;
   }
   .footer & {
-    @include media-query(medium) {
+    @include media-query(small) {
       flex-basis: 50%;
       max-width: 50%;
       min-width: 50%;

--- a/wagtailio/static/css/components/newsletter-signup.scss
+++ b/wagtailio/static/css/components/newsletter-signup.scss
@@ -35,7 +35,7 @@
     }
   }
   .footer & {
-    @include media-query(medium) {
+    @include media-query(small) {
       flex-basis: 66.66%;
       max-width: 66.66%;
       min-width: 66.66%;

--- a/wagtailio/static/css/components/page-heading.scss
+++ b/wagtailio/static/css/components/page-heading.scss
@@ -5,7 +5,7 @@
   text-align: center;
   margin: 0;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     margin: 0 0 $gutter * 4;
     padding: 0;
   }
@@ -20,7 +20,7 @@
     max-width: 1000px;
     margin: 0 auto;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       font-size: 24px;
     }
   }
@@ -38,7 +38,7 @@
     margin: 0 ($gutter / 2) ($gutter / 2);
     color: $color--white;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       margin: 0 $gutter / 2;
     }
 

--- a/wagtailio/static/css/components/page_content.scss
+++ b/wagtailio/static/css/components/page_content.scss
@@ -17,7 +17,7 @@
       font-size: $gutter;
       font-weight: 300;
       line-height: 1.5;
-      @include media-query(medium) {
+      @include media-query(small) {
         font-size: 18px;
         line-height: 1.35;
       }
@@ -30,7 +30,7 @@
       font-size: 24px;
       line-height: 1.25;
       @include font-smoothing;
-      @include media-query(medium) {
+      @include media-query(small) {
         font-size: $gutter;
       }
     }
@@ -45,7 +45,7 @@
     background-color: $color--interaction;
     @include transform(skew(-20deg));
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: 10px !important;
       @include transform(skew(0deg));
     }
@@ -59,7 +59,7 @@
       color: $color--white;
       @include transform(skew(20deg));
 
-      @include media-query(medium) {
+      @include media-query(small) {
         @include transform(skew(0deg));
         padding-top: 0px;
         margin: 0px;

--- a/wagtailio/static/css/components/share.scss
+++ b/wagtailio/static/css/components/share.scss
@@ -12,7 +12,7 @@
   background: rgba($color--white, 0.25);
   padding: 14px 10px 0;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     display: block;
   }
 

--- a/wagtailio/static/css/components/sidebar.scss
+++ b/wagtailio/static/css/components/sidebar.scss
@@ -1,7 +1,7 @@
 .sidebar {
   background-color: $color--headings;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     position: fixed;
     top: 0;
     z-index: 2;

--- a/wagtailio/static/css/components/structure.scss
+++ b/wagtailio/static/css/components/structure.scss
@@ -27,7 +27,7 @@
   .body {
     padding-top: $headerHeightMobile;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding-top: $headerHeight;
     }
   }

--- a/wagtailio/static/css/components/teasers.scss
+++ b/wagtailio/static/css/components/teasers.scss
@@ -19,7 +19,7 @@
     margin: 0 auto;
     max-width: $max-width;
 
-    @include media-query(medium) {  
+    @include media-query(small) {  
       grid-template-columns: 1fr 1fr;
     }
   }
@@ -38,7 +38,7 @@
       padding: ($gutter * 2) $gutter $gutter;
       transition: transform 0.2s ease 0s;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         min-height: 245px;
       }
 

--- a/wagtailio/static/css/components/teasers.scss
+++ b/wagtailio/static/css/components/teasers.scss
@@ -11,6 +11,8 @@
   &__container {
     display: grid;
     grid-template-columns: 1fr;
+    column-gap: $gutter;
+    row-gap: $gutter;
     justify-content: center;
     list-style-type: none;
     padding: 0;

--- a/wagtailio/static/css/components/teasers.scss
+++ b/wagtailio/static/css/components/teasers.scss
@@ -3,33 +3,30 @@
   margin-bottom: ($gutter * 4);
 
   &__main-heading {
-    color: $color--white;
     font-size: 42px;
     margin: 0 0 60px;
     text-align: center;
   }
 
   &__container {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr;
     justify-content: center;
     list-style-type: none;
     padding: 0;
     margin: 0 auto;
     max-width: $max-width;
+
+    @include media-query(medium) {  
+      grid-template-columns: 1fr 1fr;
+    }
   }
 
   &__item {
-    flex: 0 1 auto;
-    flex-basis: 50%;
     list-style-type: none;
     padding: 0 $gutter 0;
     margin: 0 0 ($gutter * 2);
     text-align: center;
-
-    @include media-query(medium) {
-      flex-basis: 33.333%;
-    }
 
     &__link {
       display: block;

--- a/wagtailio/static/css/components/terminal.scss
+++ b/wagtailio/static/css/components/terminal.scss
@@ -11,7 +11,7 @@
     margin: 0 auto;
     padding: 0 $gutter;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       padding: 0 ($gutter * 2);
     }
 

--- a/wagtailio/static/css/components/testimonial.scss
+++ b/wagtailio/static/css/components/testimonial.scss
@@ -11,7 +11,7 @@
   min-height: 400px;
   margin: 0 auto $section-space;
 
-  @include media-query(medium) {
+  @include media-query(small) {
     min-height: 300px;
   }
 

--- a/wagtailio/static/css/components/text-image.scss
+++ b/wagtailio/static/css/components/text-image.scss
@@ -1,8 +1,8 @@
 .textimage {
   background-color: $color--background-light;
   text-align: left;
-  margin-bottom: ($gutter * 2);
-  padding: ($gutter * 3) 0;
+  margin: 0 (-$gutter) ($gutter * 2);
+  padding: ($gutter * 3) $gutter;
 
   .container {
     max-width: 800px;

--- a/wagtailio/static/css/components/vertical-tabs.scss
+++ b/wagtailio/static/css/components/vertical-tabs.scss
@@ -4,7 +4,7 @@
   overflow: hidden;
   padding: ($gutter * 2) 0 ($gutter * 4);
 
-  @include media-query(medium) {
+  @include media-query(small) {
     padding: $section-space 0 0;
   }
 
@@ -20,7 +20,7 @@
   h2 {
     margin: 0 ($gutter) ($gutter * 2);
 
-    @include media-query(medium) {
+    @include media-query(small) {
       margin: 0 0 ($gutter * 3);
     }
   }
@@ -35,7 +35,7 @@
     width: 30%;
     padding: 40px 0 0 60px;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       display: block;
       width: 40%;
     }
@@ -121,7 +121,7 @@
           max-width: 260px;
           transition: color 0.2s ease 0s;
 
-          @include media-query(medium) {
+          @include media-query(small) {
             display: none;
           }
 
@@ -137,7 +137,7 @@
     width: 100%;
     padding: 0 ($gutter * 2) $gutter;
 
-    @include media-query(medium) {
+    @include media-query(small) {
       display: inherit;
       width: 60%;
       padding: 0 ($gutter * 3) 0 0;
@@ -160,7 +160,7 @@
       display: block;
       margin: ($gutter * 2) auto;
 
-      @include media-query(medium) {
+      @include media-query(small) {
         display: none;
       }
     }

--- a/wagtailio/static/css/pages/standard.scss
+++ b/wagtailio/static/css/pages/standard.scss
@@ -5,6 +5,8 @@
 */
 .template-standard-page {
   .page-content {
+    margin: 0 $gutter;
+
     h2,
     h3,
     h4 {

--- a/wagtailio/static/css/variables.scss
+++ b/wagtailio/static/css/variables.scss
@@ -68,7 +68,8 @@ $max-width: 1400px;
 
 // Breakpoints
 $breakpoints: (
-  "medium" "(min-width: 599px)",
+  "small" "(min-width: 599px)",
+  "medium" "(min-width: 899px)",
   "large" "(min-width: 1023px)",
   "extra-large" "(min-width: 1440px)",
   "mobileOnly" "(max-width: 599px)"

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -86,9 +86,13 @@ $(function() {
 
   // Window resize
   $(window).on("resize", function() {
+    // Scrolling inside the sidebar list
+    // causes the resize event to fire on Chrome Android.
+    // Disabled to fix this bug
+
     // Close nav on resize
-    $("body").removeClass("mobile_nav-open");
-    $("body").removeClass("sidebar-open");
+    // $("body").removeClass("mobile_nav-open");
+    // $("body").removeClass("sidebar-open");
   });
 
   /***

--- a/wagtailio/templates/includes/copyright.html
+++ b/wagtailio/templates/includes/copyright.html
@@ -3,7 +3,7 @@
 <div class="copyright">
     <div class="copyright__container">
         <p class="copyright__text">Wagtail is an open source project by Torchbox. &copy; {% now "Y" %}</p>
-        <a href="http://www.torchbox.com" class="torchbox" aria-label="Site by Torchbox">
+        <a href="https://torchbox.com/wagtail-cms/" class="torchbox" aria-label="Site by Torchbox">
             <span class="torchbox__container">
                 <svg class="torchbox__logo" height="25px" width="100px">
                     <use xlink:href="#torchbox"></use>


### PR DESCRIPTION
This PR will fix a few issues with responsiveness on small screen sizes.

- Fixed an issue with developer resources cards on the developers page not aligning properly on small screen sizes.
- Fixed an issue with the page border margin. There was not enough space between content and the page border.
- Fixed additional features section on the features page to be responsive
- Fixed references to Torchbox.com to go to the special Wagtail landing page.
- Fixed blog navigation bug on android. Scrolling will cause the navigation drawer to be closed because the resize event fires.
- Fixed blog post listing responsiveness. Posts would previously overlap each other on small screen sizes.
- Fixed a z-index issue on the hero section. Text would be partially obscured on small screen sizes.
- Fixed the primary menu items wrapping on medium to small screen sizes. Fix involves enabling the menu on medium screen sizes. Media queries have been altered for consistency.