### PR TITLE
Fix link appearance to be more recognisable. Mobile menu fixes.

### DIFF
--- a/wagtailio/blog/templates/blog/blog_page.html
+++ b/wagtailio/blog/templates/blog/blog_page.html
@@ -46,7 +46,7 @@
                     {% image page.author.image fill-55x55 alt=page.author.name %}
                 </div>
                 <div class="details">
-                    <h2><a href="{{ page.author.url }}">{{ page.author.name }}</a></h2>
+                    <h2><a class="blog-author" href="{{ page.author.url }}">{{ page.author.name }}</a></h2>
                     <span class="role">{{ page.author.job_title }}</span>
                 </div>
             </div>

--- a/wagtailio/static/css/components/blog.scss
+++ b/wagtailio/static/css/components/blog.scss
@@ -10,6 +10,10 @@
   }
 }
 
+.blog-author {
+  border-bottom: none !important;
+}
+
 .blog-item {
   direction: ltr;
   padding: $headerHeight $gutter;
@@ -30,6 +34,10 @@
 
     a {
       border-bottom: 2px solid $color--lagoon;
+
+      &:hover {
+        border-bottom-color: $color--coral;
+      }
     }
   }
 

--- a/wagtailio/static/css/components/blog.scss
+++ b/wagtailio/static/css/components/blog.scss
@@ -27,6 +27,10 @@
   .container {
     max-width: 800px;
     margin: 0 auto;
+
+    a {
+      border-bottom: 2px solid $color--lagoon;
+    }
   }
 
   img {

--- a/wagtailio/static/css/components/nav-item.scss
+++ b/wagtailio/static/css/components/nav-item.scss
@@ -28,9 +28,7 @@
       display: block;
       padding: ($gutter / 2) 0;
       color: $color--white;
-      text-transform: uppercase;
       font-size: 16px;
-      font-weight: 500;
       border: solid 1px transparent;
       transition: color 0.2s ease, opacity 0.2s ease, background-color 0.2s ease;
 
@@ -39,6 +37,10 @@
         color: $color--primary;
         background-color: $color--white;
       }
+    }
+
+    #{$root}__icon {
+      fill: $color--white;
     }
   }
 }

--- a/wagtailio/static/css/components/page_content.scss
+++ b/wagtailio/static/css/components/page_content.scss
@@ -9,6 +9,7 @@
 .page-content > .container {
   a {
     word-wrap: break-word;
+    border-bottom: 2px solid $color--lagoon;
   }
   ol,
   ul {

--- a/wagtailio/static/css/components/page_content.scss
+++ b/wagtailio/static/css/components/page_content.scss
@@ -10,6 +10,10 @@
   a {
     word-wrap: break-word;
     border-bottom: 2px solid $color--lagoon;
+
+    &:hover {
+      border-bottom-color: $color--coral;
+    }
   }
   ol,
   ul {
@@ -105,6 +109,17 @@
         .name {
         }
       }
+    }
+  }
+}
+
+.rich-text {
+
+  a {
+    border-bottom: 2px solid $color--lagoon;
+
+    &:hover {
+      border-bottom-color: $color--coral;
     }
   }
 }


### PR DESCRIPTION
This PR adds/fixes: 
- underline for links to make them more recognisable as links. Similar to the look of torchbox.com.
- Remove mobile menu font weight and uppercasing.
- Fix mobile menu documentation icon not visible against background.

![image](https://user-images.githubusercontent.com/13856515/76309253-53f68b80-62c4-11ea-9c0f-ea016235ebbc.png)
