### PR TITLE
Avoid using original image renditions in templates

### DIFF
--- a/wagtailio/blog/templates/blog/blog_page.html
+++ b/wagtailio/blog/templates/blog/blog_page.html
@@ -51,7 +51,7 @@
                 </div>
             </div>
 
-            {% image page.main_image original %}
+            {% image page.main_image width-800 %}
             {% include_block page.body %}
 
         </div>

--- a/wagtailio/core/templates/core/includes/streamfield.html
+++ b/wagtailio/core/templates/core/includes/streamfield.html
@@ -2,7 +2,6 @@
 
 
 {% for child in value %}
-
     {% if child.block_type == 'h2' %}
 
         <h2>{{ child }}</h2>
@@ -34,6 +33,8 @@
             </blockquote>
         </div>
 
+    {% elif child.block_type == 'image' %}
+        <div class="paragraph">{% image child.value width-800 %}</div>
     {% elif child.block_type == 'imagecaption' %}{# img-full-text #}
 
         <div class="imagecaption">


### PR DESCRIPTION
Fixes #56

- StreamField image block
- blog post main image