### PR TITLE
Add blog post main image/intro as fallbacks for meta desc/image

### DIFF
--- a/wagtailio/templates/base.html
+++ b/wagtailio/templates/base.html
@@ -15,15 +15,16 @@
         <meta name="twitter:site" content="@wagtailcms" />
         <meta name="twitter:creator" content="@wagtailcms" />
         <meta name="twitter:title" content="{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %} | Wagtail CMS" />
-        <meta name="twitter:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% endif %}" />
-        <meta name="twitter:image" content="{% if page.social_image %}{% image page.social_image width-400 as img %}{{ img.url }}{% else %}{% static 'img/default-sharing-image.png' %}{% endif %}" />
+        <meta name="twitter:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% elif page.introduction %}{{ page.introduction|truncatechars:160 }}{% endif %}" />
+        <meta name="twitter:image" content="{% if page.social_image %}{% image page.social_image width-400 as img %}{{ img.url }}
+        {% elif page.main_image %}{% image page.main_image width-400 as img %}{{ img.url }}{% else %}{% static 'img/default-sharing-image.png' %}{% endif %}" />
 
         <meta property="fb:app_id" content="{{ FB_APP_ID }}" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://{{ request.site.hostname }}{{ page.url }}" />
         <meta property="og:title" content="{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %} | Wagtail CMS" />
-        <meta property="og:image" content="{% if page.social_image %}{% image page.social_image width-1024 as img %}{{ img.url }}{% else %}{% static 'img/default-sharing-image.png' %}{% endif %}" />
-        <meta property="og:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% endif %}" />
+        <meta property="og:image" content="{% if page.social_image %}{% image page.social_image width-1024 as img %}{{ img.url }}{% elif page.main_image %}{% image page.main_image width-1024 as img %}{{ img.url }}{% else %}{% static 'img/default-sharing-image.png' %}{% endif %}" />
+        <meta property="og:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% elif page.introduction %}{{ page.introduction|truncatechars:200 }}{% endif %}" />
         <meta property="og:site_name" content="Wagtail CMS" />
 
         <link title="The Wagtail CMS Blog" type="application/atom+xml" rel="alternate" href="{% url 'blog_feed' %}">


### PR DESCRIPTION
Fixes #51

The intro is truncated to 160 chars for meta description and 200 for og:description as those seem to be the max recommended values based on my research.