### PR TITLE
Update wagtailaltgenerator to use official release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-redis==4.9.0
 django-basic-auth-ip-whitelist==0.3.4
 scout-apm==1.1.7
 django-referrer-policy==1.0
-https://zerolab.org/_dumps/wagtailaltgenerator-4.1.2a0-py3-none-any.whl
+wagtailaltgenerator==4.1.2
 wagtail-content-import==0.4.1
 mammoth==1.4.10
 


### PR DESCRIPTION
https://github.com/marteinn/wagtail-alt-generator/pull/39 has been merged and v4.1.2 is out