### PR TITLE
Use Wagtail ID as the unique field for airtable mapping

### DIFF
--- a/wagtailio/blog/models.py
+++ b/wagtailio/blog/models.py
@@ -107,6 +107,7 @@ class BlogPage(AirtableMixin, Page, ContentImportMixin, SocialMediaMixin, CrossP
 
     def get_export_fields(self):
         return {
+            "ID": self.id,
             "Title": self.title,
             "Live": self.live,
             "Slug": self.slug,

--- a/wagtailio/features/models.py
+++ b/wagtailio/features/models.py
@@ -87,6 +87,7 @@ class FeatureDescription(AirtableMixin, ClusterableModel):
         Get field mappings for Airtable when saving a model object.
         """
         return {
+            "ID": self.id,
             "Title": self.title,
             "Introduction": self.introduction,
             "Documentation": self.documentation_link

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -468,7 +468,7 @@ AIRTABLE_IMPORT_SETTINGS = {
         'AIRTABLE_BASE_KEY': BLOG_AIRTABLE_BASE_KEY,
         'AIRTABLE_TABLE_NAME': 'Posts',
         'AIRTABLE_UNIQUE_IDENTIFIER': {
-            'Slug': 'slug',
+            'ID': 'id',
         },
         'AIRTABLE_SERIALIZER': 'wagtailio.blog.serializers.BlogPageSerializer',
         'AIRTABLE_BASE_URL': BLOG_AIRTABLE_URL,
@@ -477,7 +477,7 @@ AIRTABLE_IMPORT_SETTINGS = {
         'AIRTABLE_BASE_KEY': FEATURES_AIRTABLE_BASE_KEY,
         'AIRTABLE_TABLE_NAME': 'Feature Descriptions',
         'AIRTABLE_UNIQUE_IDENTIFIER': {
-            'Title': 'title',
+            'ID': 'id',
         },
         'AIRTABLE_SERIALIZER': 'wagtailio.features.serializers.FeatureDescriptionSerializer',
         'AIRTABLE_BASE_URL': FEATURES_AIRTABLE_URL,


### PR DESCRIPTION
Blog pages can sit outside blog section so slug is not actually guaranteed unique - eg with current data the slug 'test' is not unique so will cause problems.