### PR TITLE
docs.wagtail.io cloudflare worker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ To staging
 To production
 
 `fab deploy_production`
+
+
+## docs.wagtail.io
+
+Wagtail documentation is hosted at [readthedocs](https://readthedocs.org/). A Cloudflare worker is in place to rewrite canonical URLs on old versions of the documentation - see `conf/wagtaildocs-cloudflare-worker.js`.

--- a/conf/wagtaildocs-cloudflare-worker.js
+++ b/conf/wagtaildocs-cloudflare-worker.js
@@ -1,0 +1,53 @@
+/*
+docs.wagtail.io canonical URL rewriter
+
+This script is installed as a Cloudflare worker on docs.wagtail.io to ensure that the
+<link rel="canonical"> tag on all pages is pointing to the 'stable' version of the docs.
+Certain older versions of the docs were built at a time when the 'default' version set
+on readthedocs was pointing to the specific then-current release, and due to changes in
+the readthedocs build environment or external dependencies, cannot be rebuilt without
+deleting and recreating the corresponding tags in Wagtail's git repo. As a result, the
+stale 'canonical' links persist, leading to search engines prioritising the older
+versions over the current stable one.
+*/
+
+// The hostname we will fetch documentation pages from. This is configured in readthedocs
+// as an alternative (non-default) hostname with HTTPS disabled; this avoids any issues
+// with the docs.wagtail.io DNS and SSL certificate being handled by us vs. readthedocs.
+const originDomain = 'wagtaildocs.demozoo.org';
+
+// The hostname that incoming requests will come in on
+const proxyDomain = 'docs.wagtail.io';
+
+const originRoot = 'http://' + originDomain + '/';
+const proxyRoot = 'https://' + proxyDomain + '/';
+
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request))
+})
+
+class CanonicalLinkHandler {
+  element(element) {
+    const oldUrl = element.getAttribute('href');
+    // Rewrite any URL paths within /latest/ or /vN.N/ to the corresponding path in /stable/
+    const newUrl = oldUrl.replace(/^(https?\:\/\/docs\.wagtail\.io\/\w+)\/(v[\d\.]+|latest)\//, '$1/stable/');
+    element.setAttribute('href', newUrl);
+  }
+}
+
+/* Respond to the request */
+async function handleRequest(request) {
+  // Fetch from the origin host
+  const originUrl = request.url.replace(proxyRoot, originRoot);
+  const resp = await fetch(originUrl, {redirect: 'manual'});
+
+  // Only rewrite responses with an html content type
+  const contentType = resp.headers.get('Content-Type');
+  if (contentType && contentType.split(';')[0].endsWith('html')) {
+    return new HTMLRewriter().on(
+      'link[rel="canonical"]', new CanonicalLinkHandler()
+    ).transform(resp);
+  } else {
+    return resp;
+  }
+}


### PR DESCRIPTION
Not specifically related to this codebase, but added here to keep it safe...

This is the cloudflare worker used on docs.wagtail.io to rewrite `<link rel="canonical">` URLs in old versions of the docs to point to the 'stable' branch, to hopefully ensure that Google is indexing up-to-date versions of the docs.