### PR TITLE
Add page title to 404 page

### DIFF
--- a/wagtailio/templates/404.html
+++ b/wagtailio/templates/404.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}Page not found{% endblock %}
+
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Otherwise it just shows the title suffix, and starting with a `|`  looks unintentional