### PR TITLE
Add A/B testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ wagtail-content-import==0.4.2
 wagtail-image-import==0.1.0
 wagtail-transfer==0.5.1
 mammoth==1.4.10
+wagtail-ab-testing==0.2
 
 
 # Pinned as django-redis has incompatibility with later versions

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ wagtail-content-import==0.4.2
 wagtail-image-import==0.1.0
 wagtail-transfer==0.5.1
 mammoth==1.4.10
-wagtail-ab-testing==0.2
+wagtail-ab-testing==0.2.1
 
 
 # Pinned as django-redis has incompatibility with later versions

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = (
     "compressor",
     "taggit",
     "modelcluster",
+    "wagtail_ab_testing",
     "wagtail_transfer",
     "wagtail_airtable",
     "wagtail.core",
@@ -384,7 +385,7 @@ WAGTAILIMAGES_IMAGE_MODEL = "images.WagtailioImage"
 
 if "PRIMARY_HOST" in env:
     BASE_URL = "http://%s/" % env["PRIMARY_HOST"]
-    
+
 # https://docs.wagtail.io/en/v2.8.1/releases/2.8.html#responsive-html-for-embeds-no-longer-added-by-default
 WAGTAILEMBEDS_RESPONSIVE_HTML = True
 
@@ -443,7 +444,7 @@ WAGTAILIMAGEIMPORT_GOOGLE_OAUTH_CLIENT_SECRET = env.get(
 )
 
 WAGTAILIMAGEIMPORT_FIELD_MAPPING = {
-    "id": "driveidmapping__drive_id", 
+    "id": "driveidmapping__drive_id",
     "name": "title",
     "imageMediaMetadata__time": "exif_datetime",
     "md5Checksum": "md5_hash"


### PR DESCRIPTION
We want to be able to test wagtail-ab-testing a bit more, and maybe run some tests on the wagtail.io site for fun. So I added the wagtail a/b testing package to the site. Tested on a fresh install and it works out of the box. 

