### PR TITLE
Make videos responsive

### DIFF
--- a/wagtailio/static/css/components/base.scss
+++ b/wagtailio/static/css/components/base.scss
@@ -131,7 +131,8 @@ Other global items
 
   iframe,
   embed,
-  object {
+  object,
+  video {
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
This tweak makes videos embedded with the <video> tag adjust their width to the size of the screen.