### PR TITLE
Stop scroll to top on cookies close button

### DIFF
--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -150,7 +150,8 @@ $(function() {
   }
   // Bind cookie dismiss handler
   if(dismissButton) {
-    dismissButton.click(function () {
+    dismissButton.click(function (event) {
+      event.preventDefault(); // ensure the href is not used (scrolls user to the top)
       Cookies.set('client-cookie', 'agree to cookies', {
         expires: 365, // Cookie expires after 365 days
       });


### PR DESCRIPTION
* Ensure that when users click the 'close' button on the cookies message it does not scroll to the top
* As the button is a link, when clicked it will go to the `href='#'` which will move the user to the stop
* Prevent this action using event.preventDefault
* Note: I only tested manually in the browser (using jquery), not by building the site locally

Screenshot of issue (note the href="#").
![Screen Shot 2021-08-06 at 10 04 04 pm](https://user-images.githubusercontent.com/1396140/128508459-da6e45d4-4f83-4da7-8d80-61525b307144.png)
