### PR TITLE
[AreWeHeadlessYet] Add last_published_at to API fields

### DIFF
--- a/wagtailio/areweheadlessyet/models.py
+++ b/wagtailio/areweheadlessyet/models.py
@@ -51,6 +51,7 @@ class AreWeHeadlessYetHomePage(Page, SocialMediaMixin, CrossPageMixin):
     ]
 
     api_fields = [
+        APIField("last_published_at"),
         APIField("strapline_icon"),
         APIField("strapline_text"),
         APIField("body"),
@@ -89,6 +90,7 @@ class AreWeHeadlessYetTopicPage(Page, SocialMediaMixin, CrossPageMixin):
     ]
 
     api_fields = [
+        APIField("last_published_at"),
         APIField("status_color"),
         APIField("introduction"),
         APIField("body"),


### PR DESCRIPTION
This PR includes the `last_published_at` value in the API fields. We need it to show when the page was last updated in the frontend side.