### PR TITLE
Corrected typo in signup form template resulting in wrong mailchimp newsletter id

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/sign_up_form_block/sign_up_form_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/sign_up_form_block/sign_up_form_block.html
@@ -1,3 +1,3 @@
 <div class="grid">
-    {% include "patterns/components/sign_up_form/base_form.html" with classes="sign-up-form--block" heading=value.heading sub_heading=value.sub_heading mailchimp_account_id=value.mailchimp_account_id mailchimp_newsletter_id=value.mailchimp_account_id icon=True %}
+    {% include "patterns/components/sign_up_form/base_form.html" with classes="sign-up-form--block" heading=value.heading sub_heading=value.sub_heading mailchimp_account_id=value.mailchimp_account_id mailchimp_newsletter_id=value.mailchimp_newsletter_id icon=True %}
 </div>


### PR DESCRIPTION
Corrected typo in signup form template resulting in wrong mailchimp newsletter id.