### PR TITLE
Ensure 404 and 500 views return correct status codes

### DIFF
--- a/wagtailio/utils/views.py
+++ b/wagtailio/utils/views.py
@@ -18,8 +18,8 @@ def robots(request):
 
 
 def error_404(request, exception=None):
-    return render(request, "patterns/pages/errors/404.html", {})
+    return render(request, "patterns/pages/errors/404.html", {}, status=404)
 
 
 def error_500(request, exception=None):
-    return render(request, "patterns/pages/errors/500.html", {})
+    return render(request, "patterns/pages/errors/500.html", {}, status=500)


### PR DESCRIPTION
When implementing custom 404 / 500 views, they still need to return the correct status codes

This may be causing the issues we're seeing with redirects not working.