### PR TITLE
Fix: Increase logo visibility in contrast themes / high-contrast mode #463

### DIFF
--- a/wagtailio/static/sass/components/_logos.scss
+++ b/wagtailio/static/sass/components/_logos.scss
@@ -49,6 +49,8 @@
         min-width: 100px;
         max-width: 100px;
         flex-basis: 100px;
+        background-color: $color--white;
+        forced-color-adjust: none;
 
         .theme-dark & {
             min-width: 120px;
@@ -68,6 +70,7 @@
             padding: 10px 20px;
             background-color: $color--white;
             border-radius: 3px;
+            forced-color-adjust: none;
         }
     }
 }


### PR DESCRIPTION
This is my first PR, so if I made any mistakes, please excuse me and kindly guide me in the right direction. I hope to learn something new through this! 

The issue is #463 

To solve this issue, I followed @thibaudcolas sir's suggestion of adding" forced-color-adjust: none". It successfully worked when switching to system's high-contrast mode from website's dark mode.

However, while testing in light mode, there was no specific background color applied to the logo, which made it easy for contrast themes to override it. So, I explicitly added background-color: white here (these styles are applied in light mode):

![image](https://github.com/user-attachments/assets/03cab9f0-16bc-4590-9e9a-982d7a057a53)

these are the styles applying in the light mode of the website.

During testing, I also observed that PNG format logos are better in such cases, since their background color can be styled easily. For other formats, the appearance may not be ideal. You can see the difference here:

![image](https://github.com/user-attachments/assets/36b1edbf-4607-4c2a-8f4a-2b54fa597ceb)

The first logo is a PNG.
The second one is not, and does not blend well.

I tested this in Chrome, Microsoft Edge and Fire Fox browsers.
