### PR TITLE
Refactor social sharing meta

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/base_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/base_page.html
@@ -18,6 +18,23 @@
         {% image page.main_image fill-1200x630 as social_img %}
     {% endif %}
 
+    <meta property="og:title" content="{% if page %}{% firstof page.seo_title page.title %} | {% endif %}Wagtail CMS" />
+    <meta property="og:type" content="website" />
+    {% if page %}
+        <meta property="og:url" content="{% fullpageurl page %}" />
+    {% endif %}
+    {% if social_img %}
+        <meta property="og:image" content="{{ social_img.url }}" />
+        <meta property="og:image:width" content="{{ social_img.width }}" />
+        <meta property="og:image:height" content="{{ social_img.height }}" />
+    {% else %}
+        <meta property="og:image" content="{{ site.root_url }}{% static 'img/default-sharing-image.png' %}" />
+    {% endif %}
+    <meta property="og:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% elif page.introduction %}{{ page.introduction|truncatechars:200 }}{% endif %}" />
+    <meta property="og:site_name" content="Wagtail CMS" />
+
+    {% if FB_APP_ID %}<meta property="fb:app_id" content="{{ FB_APP_ID }}" />{% endif %}
+
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@wagtailcms" />
     <meta name="twitter:creator" content="@wagtailcms" />
@@ -29,24 +46,6 @@
     {% else %}
         <meta name="twitter:image" content="{{ site.root_url }}{% static 'img/default-sharing-image.png' %}" />
     {% endif %}
-
-    {% if FB_APP_ID %}<meta property="fb:app_id" content="{{ FB_APP_ID }}" />{% endif %}
-    <meta property="og:type" content="website" />
-
-    {% if page %}
-        <meta property="og:url" content="{% fullpageurl page %}" />
-    {% endif %}
-    <meta property="og:title" content="{% if page %}{% firstof page.seo_title page.title %} | {% endif %}Wagtail CMS" />
-
-    {% if social_img %}
-        <meta property="og:image" content="{{ social_img.url }}" />
-        <meta property="og:image:width" content="{{ social_img.width }}" />
-        <meta property="og:image:height" content="{{ social_img.height }}" />
-    {% else %}
-        <meta property="og:image" content="{{ site.root_url }}{% static 'img/default-sharing-image.png' %}" />
-    {% endif %}
-    <meta property="og:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% elif page.introduction %}{{ page.introduction|truncatechars:200 }}{% endif %}" />
-    <meta property="og:site_name" content="Wagtail CMS" />
 
     <link title="The Wagtail CMS Blog" type="application/atom+xml" rel="alternate" href="{% url 'blog_feed' %}">
     <link title="This Week in Wagtail" type="application/atom+xml" rel="alternate" href="{% url 'newsletter_feed' %}">

--- a/wagtailio/project_styleguide/templates/patterns/base_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/base_page.html
@@ -11,36 +11,32 @@
         <link rel="canonical" href="{% firstof page.canonical_url page.full_url %}" />
     {% endif %}
 
+    {% wagtail_site as site %}
+    {% if page.social_image %}
+        {% image page.social_image fill-1200x630 as social_img %}
+    {% elif page.main_image %}
+        {% image page.main_image fill-1200x630 as social_img %}
+    {% endif %}
+
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@wagtailcms" />
     <meta name="twitter:creator" content="@wagtailcms" />
     <meta name="twitter:title" content="{% if page %}{% firstof page.seo_title page.title %} | {% endif %}Wagtail CMS" />
     <meta name="twitter:description" content="{% if page.social_text %}{{ page.social_text }}{% elif page.listing_intro %}{{ page.listing_intro }}{% elif page.introduction %}{{ page.introduction|truncatechars:160 }}{% endif %}" />
-
-    {% wagtail_site as site %}
-    {% if page.social_image %}
-        {% image page.social_image width-400 as twitter_img %}
-    {% elif page.main_image %}
-        {% image page.main_image width-400 as twitter_img %}
-    {% endif %}
-    {% if twitter_img %}
-        <meta name="twitter:image" content="{{ twitter_img.url }}" />
-        {% if twitter_img.alt %}<meta name="twitter:image:alt" content="{{ twitter_img.alt }}" />{% endif %}
+    {% if social_img %}
+        <meta name="twitter:image" content="{{ social_img.url }}" />
+        {% if social_img.alt %}<meta name="twitter:image:alt" content="{{ social_img.alt }}" />{% endif %}
     {% else %}
         <meta name="twitter:image" content="{{ site.root_url }}{% static 'img/default-sharing-image.png' %}" />
     {% endif %}
 
     {% if FB_APP_ID %}<meta property="fb:app_id" content="{{ FB_APP_ID }}" />{% endif %}
     <meta property="og:type" content="website" />
+
     {% if page %}
         <meta property="og:url" content="{% fullpageurl page %}" />
     {% endif %}
     <meta property="og:title" content="{% if page %}{% firstof page.seo_title page.title %} | {% endif %}Wagtail CMS" />
-    {% if page.social_image %}
-        {% image page.social_image width-1200 height-627 as social_img %}
-    {% elif page.main_image %}
-        {% image page.main_image width-1200 height-627 as social_img %}
-    {% endif %}
 
     {% if social_img %}
         <meta property="og:image" content="{{ social_img.url }}" />


### PR DESCRIPTION
Fixes #514
Updated social sharing image dimensions using `fill-1200x630` to match recommended sizes across most of the platforms.

Additional Note:
Some blog posts currently do not meet the required minimum description length of 100 characters. we could consider adding `min=100` to the introduction field.
Not sure about all other platforms, but linkedin recommends a minimum of 100 characters.