### PR TITLE
Hotfix for Wagtail Space navigation logo

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/includes/spaceheader.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/spaceheader.html
@@ -4,7 +4,7 @@
     {% include "patterns/components/skip-link/skip-link.html" %}
 
     <div class="header__identity">
-        {% if page.get_verbose_name == 'Wagtail Space Page' or 'Wagtail Space Schedule Page' %}
+        {% if page.get_verbose_name == 'Wagtail Space Page' or page.get_verbose_name == 'Wagtail Space Schedule Page' %}
             <a href="{% pageurl page.get_parent %}" aria-label="Wagtail.org homepage">
                 <img src="{% static 'img/WagtailSpace2025Logo.png' %}" alt="Wagtail Space 2025">
             </a>


### PR DESCRIPTION
I wasn't explicit enough in my code and so the wrong logo was showing. This fix corrects that.