### PR TITLE
Removing Wagtail Space 2025 banner

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/base_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/base_page.html
@@ -87,18 +87,6 @@
 {% endblock body_top %}
 
 {% block header %}
-    {% if '/wagtail-space' not in request.path %}
-    <!-- This content will NOT show on any URL containing /wagtail-space -->
-        {% if '/wagtail-space' not in request.path %}
-            <div class="space-banner">
-                <div class="banner-text">Join us for</div>
-                <img src="{% static 'img/WagtailSpace2025Logo.png' %}"
-                     alt="Registration banner"
-                     class="banner-image">
-                <a href="/wagtail-space-2025" class="banner-button">Learn more</a>
-            </div>
-        {% endif %}
-    {% endif %}
     {% include "patterns/includes/header.html" %}
 {% endblock header %}
 


### PR DESCRIPTION
We need to remove the banner for Wagtail Space 2025. I'm removing the banner from our base template but leaving the styles in place so that we can repurpose them for our next event banner.