### PR TITLE
fix missing data in related pages card (#558)

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html
@@ -5,7 +5,7 @@
         <div class="related-content__items">
             {% for related in related_pages %}
                 <article class="related-content__item">
-                    {% include "patterns/components/streamfields/cards/related_page_card_block.html" with value=related.page classes="logo-card--article" %}
+                    {% include "patterns/components/streamfields/cards/related_page_card_block.html" with value=related.page.specific classes="logo-card--article" %}
                 </article>
             {% endfor %}
         </div>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
@@ -16,7 +16,11 @@ The reason for the separation is because of differing context variable names, fo
         <h4 class="logo-card__heading teaser-heading">{{ value.title }}</h4>
     {% endif %}
 
-    <div class="logo-card__description">{{ value.introduction }}</div>
+    {% if value.introduction %}
+        <div class="logo-card__description">{{ value.introduction }}</div>
+    {% elif value.intro %}
+        <div class="logo-card__description">{{ value.intro }}</div>
+    {% endif %}
 
     {% if value.author %}
         <div class="logo-card__author-wrap">


### PR DESCRIPTION
This PR  fixes #558 

changes:
- Pass the correct page instance `(.specific)` when rendering` related_page_card_block.html`.
- Update` related_page_card_block.html` to display data even when certain fields (like` introduction or intro) `are missing on a page type.