### PR TITLE
Fix invalid block tag ifnotequal used by swapping to the new querystring tag

### DIFF
--- a/wagtailio/newsletter/templates/newsletter/newsletter_index_page.html
+++ b/wagtailio/newsletter/templates/newsletter/newsletter_index_page.html
@@ -69,7 +69,7 @@
         {% if newsletters.has_next %}
             <div class="grid">
                 <div class="button-align button-align--home">
-                    <a href="?page={{ newsletters.next_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&{{ key }}={{ value }}{% endifnotequal %}{% endfor %}" class="button">
+                    <a href="{% querystring page=newsletters.next_page_number %}" class="button">
                         <p class="button__text">Older</p>
                         <svg class="arrow" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                     </a>


### PR DESCRIPTION
Fixes

```
KeyError: 'ifnotequal'
django.template.exceptions.TemplateSyntaxError: Invalid block tag on line 72: 'ifnotequal', expected 'empty' or 'endfor'. Did you forget to register or load this tag?
```

by switching to https://docs.djangoproject.com/en/5.1/releases/5.1/#querystring-template-tag.

This is the template for the [newsletter archive](https://wagtail.org/this-week-in-wagtail/).