### PR TITLE
Fix mobile menu scrolling in landscape mode

### DIFF
--- a/wagtailio/static/sass/layout/_header.scss
+++ b/wagtailio/static/sass/layout/_header.scss
@@ -85,7 +85,8 @@
             &.is-visible {
                 visibility: visible;
                 transform: translateZ(0);
-                overflow-y: scroll;
+                max-height: calc(100vh - #{$header-mobile-height});
+                overflow-y: auto;
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where the mobile navigation menu could not be fully scrolled in landscape mode, making the "Get started" button unreachable.

The mobile menu height is now constrained relative to the header height, enabling proper vertical scrolling when the menu is open.

Fixes #304