### PR TITLE
Improved decorative shapes and headlines around it

### DIFF
--- a/wagtailio/static/sass/components/_headline.scss
+++ b/wagtailio/static/sass/components/_headline.scss
@@ -43,6 +43,19 @@
             padding-top: $gutter-lg;
         }
     }
+    @include media-query(small) {
+        &__heading {
+            display: inline-block;
+            background-color: color-mix(
+                in srgb,
+                var(--color-background) 70%,
+                transparent
+            );
+            padding: 0.25em 0.5em;
+            border-radius: 4px;
+        }
+    }
+
 
     &__subheading {
         margin-bottom: 20px;

--- a/wagtailio/static/sass/layout/_header.scss
+++ b/wagtailio/static/sass/layout/_header.scss
@@ -85,7 +85,8 @@
             &.is-visible {
                 visibility: visible;
                 transform: translateZ(0);
-                overflow-y: scroll;
+                max-height: calc(100vh - #{$header-mobile-height});
+                overflow-y: auto;
             }
         }
     }


### PR DESCRIPTION
This implements the remaining part of the suggested fix for #457.

At viewport widths ≤768px, section subheadings can be visually impacted by decorative shapes. This change adds a theme-aware, semi-transparent background behind the heading text on small screens to improve readability while preserving the decorative artwork.

I verified the change visually using browser DevTools in both light and dark modes.

Let me know if there are any changes that can be made.
