### PR TITLE
Improve Wagtail logo visibility in forced-colors mode

### DIFF
--- a/wagtailio/static/sass/layout/_header.scss
+++ b/wagtailio/static/sass/layout/_header.scss
@@ -26,7 +26,7 @@
         height: 100%;
 
         @media (forced-colors: active) {
-            fill: CanvasText;
+            forced-color-adjust: none;
         }
 
         &--dark {


### PR DESCRIPTION
This fixes an issue where the Wagtail bird logo lost its internal details in forced-colors / high-contrast mode, causing it to appear as a flat shape. The change keeps the logo readable while leaving the rest of the UI unaffected (#303).