### PR TITLE
Fix mobile menu toggle on touch devices

### DIFF
--- a/wagtailio/static/js/components/mobile-menu.js
+++ b/wagtailio/static/js/components/mobile-menu.js
@@ -32,8 +32,8 @@ class MobileMenu {
     }
 
     bindEventListeners() {
-        // Use mousedown since click events are being prevented
-        this.node.addEventListener('mousedown', (e) => {
+        // Use pointerup for reliable mobile/touch interaction
+        this.node.addEventListener('pointerup', (e) => {
             e.preventDefault();
             e.stopPropagation();
             this.toggle();


### PR DESCRIPTION
Fixes #586 

Fixes the mobile menu toggle not closing on touch devices.

The toggle was bound to `mousedown`, which doesn’t reliably fire for subsequent taps on mobile browsers. This meant the menu could be opened but not closed again, leaving the navigation stuck open (and keeping page scroll locked).

This switches the event handler to `pointerup` for more reliable touch interaction.