### PR TITLE
Fix poor color contrast for cancel icon hover state in light mode

### DIFF
--- a/wagtailio/static/sass/components/_modal.scss
+++ b/wagtailio/static/sass/components/_modal.scss
@@ -120,12 +120,10 @@
             }
         }
 
-        .theme-dark & {
-            &:hover,
-            &:focus {
-                #{$root}__close-icon {
-                    fill: $color--teal-100;
-                }
+        &:hover,
+        &:focus {
+            #{$root}__close-icon {
+               fill: $color--teal-100;
             }
         }
     }


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #433 

### Description
In light mode, the close button icon in the search modal had a 
custom hover/focus color that only applied to the dark theme, 
causing a contrast ratio of 1.06:1 on hover — violating WCAG 
2.1 Success Criterion 1.4.3 (Contrast Minimum).

Fixed by removing the `.theme-dark` wrapper so the teal hover 
color applies in both light and dark mode, ensuring sufficient 
contrast on hover/focus.

<!-- Please describe the problem you're fixing. -->


### AI usage
Used Claude to help identify the fix. Changes reviewed and 
applied manually.
<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
