### PR TITLE
Removed stars widget.

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/includes/header.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/header.html
@@ -16,10 +16,6 @@
 
     <div class="header__actions">
 
-        <div class="header__github">
-            <a class="github-button" href="https://github.com/wagtail/wagtail"  data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-star" size="large" data-show-count="true" aria-label="Visit Wagtail on GitHub to star the repo">Star</a>
-        </div>
-
         <div class="header__nav header__nav--desktop" data-desktop-menu>
             {% main_navigation %}
         </div>


### PR DESCRIPTION
### Description

We're removing the GitHub Stars widget from the top-level menu as a part of our work on refreshing the IA on wagtail.org.


### AI usage

This was old-fashioned deletion.  No AI here.
